### PR TITLE
Try to move the project urls

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,10 +25,6 @@ maintainers = [
 ]
 readme = "README.md"
 
-urls =[
-    { homepage = "https://github.com/norwegian-geotechnical-institute/sgf-parser" },
-    { repository = "https://github.com/norwegian-geotechnical-institute/sgf-parser" },
-]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Operating System :: OS Independent",
@@ -45,6 +41,11 @@ dependencies=[
 packages = [
     { include = "sgf_parser", from="src" },
 ]
+
+
+[project.urls]
+homepage = "https://github.com/norwegian-geotechnical-institute/sgf-parser"
+repository = "https://github.com/norwegian-geotechnical-institute/sgf-parser"
 
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,8 +24,11 @@ maintainers = [
      { name = "Jostein Leira", email = "jostein@leira.net" }
 ]
 readme = "README.md"
-homepage = "https://github.com/norwegian-geotechnical-institute/sgf-parser"
-repository = "https://github.com/norwegian-geotechnical-institute/sgf-parser"
+
+urls =[
+    { homepage = "https://github.com/norwegian-geotechnical-institute/sgf-parser" },
+    { repository = "https://github.com/norwegian-geotechnical-institute/sgf-parser" },
+]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Operating System :: OS Independent",


### PR DESCRIPTION
The last reorganization of the `pyproject.toml`, the documentation urls are not picked up.